### PR TITLE
BOM-free C# sources

### DIFF
--- a/Hotkeys.cs
+++ b/Hotkeys.cs
@@ -1,4 +1,4 @@
-﻿/*  AeroShot - Transparent screenshot utility for Windows
+/*  AeroShot - Transparent screenshot utility for Windows
 	Copyright (C) 2015 toe_head2001
 	Copyright (C) 2012 Caleb Joseph
 

--- a/Main.Designer.cs
+++ b/Main.Designer.cs
@@ -1,4 +1,4 @@
-﻿/*  AeroShot - Transparent screenshot utility for Windows
+/*  AeroShot - Transparent screenshot utility for Windows
 	Copyright (C) 2015 toe_head2001
 	Copyright (C) 2012 Caleb Joseph
 

--- a/Main.cs
+++ b/Main.cs
@@ -1,4 +1,4 @@
-﻿/*  AeroShot - Transparent screenshot utility for Windows
+/*  AeroShot - Transparent screenshot utility for Windows
 	Copyright (C) 2015 toe_head2001
 	Copyright (C) 2012 Caleb Joseph
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,4 @@
-﻿/*  AeroShot - Transparent screenshot utility for Windows
+/*  AeroShot - Transparent screenshot utility for Windows
 	Copyright (C) 2015 toe_head2001
 	Copyright (C) 2012 Caleb Joseph
 
@@ -23,7 +23,7 @@ using System.Windows.Forms;
 [assembly: AssemblyTitle("AeroShot Mini")]
 [assembly: AssemblyProduct("AeroShot Mini")]
 [assembly: AssemblyDescription("Screenshot capture utility for Windows Aero")]
-[assembly: AssemblyCopyright("© 2015 toe_head2001")]
+[assembly: AssemblyCopyright("\u00a9 2015 toe_head2001")]
 [assembly: AssemblyVersion("1.5.0.0")]
 [assembly: AssemblyFileVersion("1.5.0.0")]
 [assembly: ComVisible(false)]

--- a/Screenshot.cs
+++ b/Screenshot.cs
@@ -1,4 +1,4 @@
-﻿/*  AeroShot - Transparent screenshot utility for Windows
+/*  AeroShot - Transparent screenshot utility for Windows
 	Copyright (C) 2015 toe_head2001
 	Copyright (C) 2012 Caleb Joseph
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -1,4 +1,4 @@
-﻿/*  AeroShot - Transparent screenshot utility for Windows
+/*  AeroShot - Transparent screenshot utility for Windows
 	Copyright (C) 2015 toe_head2001
 	Copyright (C) 2012 Caleb Joseph
 

--- a/Tray.cs
+++ b/Tray.cs
@@ -1,4 +1,4 @@
-﻿/*  AeroShot - Transparent screenshot utility for Windows
+/*  AeroShot - Transparent screenshot utility for Windows
 	Copyright (C) 2015 toe_head2001
 
 	AeroShot is free software: you can redistribute it and/or modify

--- a/UnsafeBitmap.cs
+++ b/UnsafeBitmap.cs
@@ -1,4 +1,4 @@
-﻿/*  AeroShot - Transparent screenshot utility for Windows
+/*  AeroShot - Transparent screenshot utility for Windows
 	Copyright (C) 2012 Caleb Joseph
 
 	AeroShot is free software: you can redistribute it and/or modify

--- a/WindowsAPI.cs
+++ b/WindowsAPI.cs
@@ -1,4 +1,4 @@
-﻿/*  AeroShot - Transparent screenshot utility for Windows
+/*  AeroShot - Transparent screenshot utility for Windows
 	Copyright (C) 2015 toe_head2001
 	Copyright (C) 2012 Caleb Joseph
 


### PR DESCRIPTION
UTF-8 BOM marker can serve as a hindrance with some command line tools. It used to be added to C# source by older versions of Visual Studio but not required in this solution.